### PR TITLE
Adding image optimization

### DIFF
--- a/src/components/ImageWebP/ImageWebp.jsx
+++ b/src/components/ImageWebP/ImageWebp.jsx
@@ -1,0 +1,237 @@
+/*
+ * Image Optimization Component code belongs to Ender
+ * Medium Post -> https://medium.com/@luizimbroisi_27302/react-use-webp-images-now-e0a6c6d9cf3e
+ * GitHub Repo -> https://github.com/imbroisi/medium-react-webp
+ * 
+ * Using it on this project optimizing the serving of images using modern format WebP
+ * Detects compatible browser and serves content accordingly, otherwise defaults to original format
+*/
+
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+const transparentImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+/**
+ * Using localStorage to memorize the compatibility test results.
+ * So we don't need to test again every time you visite the site.
+ */
+const getWebpCompatibilityInfo = () => JSON.parse(localStorage.getItem('thisBrowserWebpCompatibilty'));
+const saveWebpCompatibilityInfo = info => localStorage.setItem('thisBrowserWebpCompatibilty', JSON.stringify(info));
+
+let webpCompatibilityInfo = getWebpCompatibilityInfo();
+
+const webpCompatibilityTest = () => {
+
+  /**
+   * Test images data from https://developers.google.com/speed/webp/faq#how_can_i_detect_browser_support_for_webp
+   */
+  const webpTestImages = {
+    lossy: 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA',
+    lossless: 'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==',
+    alpha: 'UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/Q9ERP8DAABWUDggGAAAABQBAJ0BKgEAAQAAAP4AAA3AAP7mtQAAAA==',
+    animation: 'UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA',
+  };
+
+  const webpTestImagesKeys = Object.keys(webpTestImages);
+  let nCompatible = 0;
+  webpCompatibilityInfo = { NONE: true };
+
+  webpTestImagesKeys.forEach((type) => {
+
+    /**
+     * Testing compatibility for this type
+     */
+    const xqImg = new Image();
+    xqImg.onload = () => {
+
+      webpCompatibilityInfo[type] = (xqImg.width > 0) && (xqImg.height > 0);
+
+      if (webpCompatibilityInfo[type]) {
+      
+        webpCompatibilityInfo.NONE = false;
+        nCompatible += 1;
+
+        if (nCompatible === webpTestImagesKeys.length) webpCompatibilityInfo.ALL = true;
+
+      }
+
+      saveWebpCompatibilityInfo(webpCompatibilityInfo);
+
+    };
+    xqImg.onerror = () => {
+      
+      webpCompatibilityInfo[type] = false;
+      saveWebpCompatibilityInfo(webpCompatibilityInfo);
+
+    };
+    xqImg.src = `data:image/webp;base64,${webpTestImages[type]}`;
+
+  });
+
+};
+
+const activateWebpCompatibility = () => {
+
+  if (!getWebpCompatibilityInfo()) webpCompatibilityTest();
+
+};
+
+class ImageWebp extends PureComponent {
+
+  actualSrc = null;
+
+  componentDidMount = () => {
+
+    /**
+     * this.actualSrc === transparentImage signs we have to test compatibility.
+     */
+    if (this.actualSrc !== transparentImage) return;
+    
+    /**
+     * webpCompatibilityInfo is common for all ImageWebp components in the project.
+     *
+     * Check if it is already set by another ImageWebp component.
+     */
+    if (!webpCompatibilityInfo) webpCompatibilityTest();
+
+    setTimeout(() => this.forceUpdate(), 0);
+
+  }
+
+  onLoad = (e) => {
+    
+    const { onLoad } = this.props;
+    if (onLoad && e.target.src !== transparentImage) onLoad(e);
+
+  }
+
+  onMouseMove = (e) => {
+    
+    const { onMouseMove } = this.props;
+    if (onMouseMove && e.target.src !== transparentImage) onMouseMove(e);
+
+  }
+
+  onMouseLeave = (e) => {
+    
+    const { onMouseLeave } = this.props;
+    if (onMouseLeave && e.target.src !== transparentImage) onMouseLeave(e);
+
+  }
+
+  render() {
+
+    const {
+      src,
+      srcWebp,
+      className,
+      style,
+      width,
+      height,
+      alt,
+    } = this.props;
+
+    this.actualSrc = src;
+
+    if (srcWebp) {
+
+      if (!webpCompatibilityInfo) {
+
+        /**
+         * Compatibility test not done yet, it will be done in componentDidMount()
+         */
+        this.actualSrc = transparentImage;
+
+      } else {
+
+        const {
+          ALL,
+          NONE,
+          lossless,
+          alpha,
+          lossy,
+          animation,
+        } = webpCompatibilityInfo;
+
+        if (ALL) {
+
+          this.actualSrc = srcWebp;
+
+        } else if (!NONE) {
+
+          if (srcWebp.lastIndexOf('.alpha.webp') === src.length - 11) {
+
+            if (alpha) this.actualSrc = srcWebp;
+
+          } else if (srcWebp.lastIndexOf('.lossless.webp') === src.length - 14) {
+
+            if (lossless) this.actualSrc = srcWebp;
+
+          } else if (srcWebp.lastIndexOf('.animation.webp') === src.length - 15) {
+
+            if (animation) this.actualSrcalSrc = srcWebp;
+
+          } else if (lossy) this.actualSrc = srcWebp;
+
+        }
+
+      }
+    
+    }
+
+    return (
+      <img
+        src={this.actualSrc}
+        className={className}
+        style={style}
+        onLoad={this.onLoad}
+        onMouseMove={this.onMouseMove}
+        onMouseLeave={this.onMouseLeave}
+        alt={alt}
+        width={width}
+        height={height}
+      />
+    );
+
+  }
+
+}
+
+ImageWebp.propTypes = {
+  src: PropTypes.string.isRequired,
+  srcWebp: PropTypes.string,
+  className: PropTypes.string,
+  style: PropTypes.objectOf(PropTypes.any),
+  width: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  height: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  onLoad: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  alt: PropTypes.string,
+};
+
+ImageWebp.defaultProps = {
+  srcWebp: null,
+  className: null,
+  style: null,
+  width: null,
+  height: null,
+  onLoad: null,
+  onMouseMove: null,
+  onMouseLeave: null,
+  alt: '',
+};
+
+
+export default ImageWebp;
+export {
+  getWebpCompatibilityInfo,
+  activateWebpCompatibility,
+};

--- a/src/components/elements/Actor/Actor.js
+++ b/src/components/elements/Actor/Actor.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { IMAGE_BASE_URL } from '../../../config';
 import PropTypes from 'prop-types';
 import './Actor.css';
+import ImageWebp from '../../ImageWebP/ImageWebp';
 
 const Actor = ({ actor }) => {
 
@@ -9,7 +10,7 @@ const Actor = ({ actor }) => {
 
   return (
     <div className="rmdb-actor">
-      <img
+      <ImageWebp
         src={actor.profile_path ? `${IMAGE_BASE_URL}${POSTER_SIZE}${actor.profile_path}` : './images/no_image.jpg'}
         alt="actorthumb"
       />

--- a/src/components/elements/Header/Header.js
+++ b/src/components/elements/Header/Header.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import './Header.css';
+import ImageWebp from '../../ImageWebp/ImageWebp';
 
 const Header = () => (
     <div className="rmdb-header">
         <div className="rmdb-header-content">
             <Link to="/">
-                <img className="rmdb-logo" src="/images/reactMovie_logo.png" alt="rmdb-logo" />                
+                <ImageWebp className="rmdb-logo" src="/images/reactMovie_logo.png" alt="rmdb-logo" />                
             </Link>
             <a href="https://www.themoviedb.org/" target="_blank">
-                <img className="rmdb-tmdb-logo" src="/images/tmdb_logo.png" alt="tmdb-logo" />
+                <ImageWebp className="rmdb-tmdb-logo" src="/images/tmdb_logo.png" alt="tmdb-logo" />
             </a>
         </div>
     </div>

--- a/src/components/elements/MovieThumb/MovieThumb.js
+++ b/src/components/elements/MovieThumb/MovieThumb.js
@@ -2,16 +2,17 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import './MovieThumb.css';
+import ImageWebp from '../../ImageWebp/ImageWebp';
 
 const MovieThumb = ({ image, movieId, movieName, clickable }) => (
   <div className="rmdb-moviethumb">
     {/* You can send props via the Links "to" object. Here we create our own "movieName" */}
     {clickable ?
       <Link to={{ pathname: `/${movieId}`,  movieName: `${movieName}`}}>
-        <img className="clickable" src={image} alt="moviethumb" />
+        <ImageWebp className="clickable" src={image} alt="moviethumb" />
       </Link>
       :
-      <img src={image} alt="moviethumb" />
+      <ImageWebp src={image} alt="moviethumb" />
     }
   </div>
 )


### PR DESCRIPTION
Found this article by https://github.com/imbroisi on Medium
https://medium.com/@luizimbroisi_27302/react-use-webp-images-now-e0a6c6d9cf3e

Decided to give it a try and see if I can improve my current lighthouse score 
![image](https://user-images.githubusercontent.com/433160/221447965-da7b2778-f686-4751-bf74-85f8db66b1e2.png)
![image](https://user-images.githubusercontent.com/433160/221447978-55f95558-4d40-4cf3-a4c2-61e43240adff.png)

LOCAL BUILD shows the following optimizations achieved
however, those are not reflected on the released site, so this lingers on, perhaps I need a preprocessor to make these images change over, but I'm afraid that will lead to additional issues down the line in dependencies

anyway, these are the local numbers when debugging
![image](https://user-images.githubusercontent.com/433160/221449734-a144f397-8ec6-47d5-998b-9cfc4bee8768.png)
