### PR TITLE
adding a static route for web app

### DIFF
--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -1,0 +1,9 @@
+{
+    "navigationFallback": {
+       "rewrite": "index.html",
+       "exclude": ["/static/media/*.{png,jpg,jpeg,gif,bmp}",   "/static/css/*"]
+    },
+    "mimeTypes": {
+        ".json": "text/json"
+    }
+}


### PR DESCRIPTION
This pull request updates the `public/staticwebapp.config.json` file to enhance routing behavior and specify MIME types for JSON files.

Routing configuration:

* Added a `navigationFallback` property to rewrite all unmatched routes to `index.html` while excluding paths matching specific patterns for static media and CSS files.

MIME type specification:

* Defined the MIME type for `.json` files as `text/json` under the `mimeTypes` property.